### PR TITLE
Adjust Docker configs for de-sol1 instance

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,44 @@
+# Creating multi-stage build for production
+FROM node:16-alpine as build
+RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev vips-dev git > /dev/null 2>&1
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
+
+WORKDIR /opt/
+COPY package.json package-lock.json ./
+RUN npm install -g node-gyp
+RUN npm config set fetch-retry-maxtimeout 600000 -g && npm install --only=production
+ENV PATH /opt/node_modules/.bin:$PATH
+WORKDIR /opt/app/src/plugins/lookup
+COPY src/plugins/lookup/package.json src/plugins/lookup/package-lock.json ./
+RUN npm install
+ENV PATH /opt/app/src/plugins/lookup/node_modules/.bin:$PATH
+WORKDIR /opt/app
+COPY . .
+RUN npm run build
+
+# Creating final production image
+FROM node:16-alpine
+RUN apk add --no-cache vips-dev bash
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
+WORKDIR /opt/
+COPY --from=build /opt/node_modules ./node_modules
+WORKDIR /opt/app
+COPY --from=build /opt/app ./
+ENV PATH /opt/node_modules/.bin:$PATH
+
+ 
+# change uid of user node inside container
+# to the same uid on the host
+# RUN usermod --uid 1076 node
+
+# we don't use a bind mount for security reasons
+# instead copy into container
+COPY ./.env /opt/app
+
+
+RUN chown -R node:node /opt/app
+USER node
+EXPOSE 1337
+CMD ["npm", "run", "develop"]

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -69,16 +69,6 @@ services:
       timeout: 5s
       retries: 3
 
-  adminer:
-    image: adminer
-    ports:
-      - 8080:8080
-    networks:
-      - strapi-de-sol1
-    restart: always
-    depends_on:
-      - strapi-de-sol1DB
-
 volumes:
   strapi-de-sol1-data:
   lookup_node_modules:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,15 +1,15 @@
 version: '3'
 services:
-  strapi-rpb:
-    container_name: strapi-rpb
+  strapi-de-sol1:
+    container_name: strapi-de-sol1
     build:
       dockerfile: ./Dockerfile.prod
-    image: strapi-rpb:latest
+    image: strapi-de-sol1:latest
     restart: unless-stopped
     env_file: .env
     environment:
       DATABASE_CLIENT: ${DATABASE_CLIENT}
-      DATABASE_HOST: strapi-rpbDB
+      DATABASE_HOST: strapi-de-sol1DB
       DATABASE_PORT: ${DATABASE_PORT}
       DATABASE_NAME: ${DATABASE_NAME}
       DATABASE_USERNAME: ${DATABASE_USERNAME}
@@ -31,13 +31,13 @@ services:
     ports:
       - 1339:1337
     networks:
-      - strapi-rpb
+      - strapi-de-sol1
     depends_on:
-      strapi-rpbDB:
+      strapi-de-sol1DB:
         condition: service_healthy
 
-  strapi-rpbDB:
-    container_name: strapi-rpbDB
+  strapi-de-sol1DB:
+    container_name: strapi-de-sol1DB
     platform: linux/amd64 #for platform error on Apple M1 chips
     restart: unless-stopped
     env_file: .env
@@ -57,12 +57,12 @@ services:
       POSTGRES_DB: ${DATABASE_NAME}
     command: postgres -c statement_timeout=10min
     volumes:
-      #- strapi-rpb-data:/var/lib/postgresql/data/ #using a volume
+      #- strapi-de-sol1-data:/var/lib/postgresql/data/ #using a volume
       - ./data/postgresql/data:/var/lib/postgresql/data/ # if you want to use a bind folder
     ports:
       - 5434:5432
     networks:
-      - strapi-rpb
+      - strapi-de-sol1
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U strapi"]
       interval: 5s
@@ -74,16 +74,16 @@ services:
     ports:
       - 8080:8080
     networks:
-      - strapi-rpb
+      - strapi-de-sol1
     restart: always
     depends_on:
-      - strapi-rpbDB
+      - strapi-de-sol1DB
 
 volumes:
-  strapi-rpb-data:
+  strapi-de-sol1-data:
   lookup_node_modules:
 
 networks:
-  strapi-rpb:
-    name: strapi-rpb
+  strapi-de-sol1:
+    name: strapi-de-sol1
     driver: bridge

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -29,7 +29,7 @@ services:
       - ./public:/opt/app/public
       - ./backup:/opt/app/backup
     ports:
-      - 1339:1337
+      - 1344:1337
     networks:
       - strapi-de-sol1
     depends_on:
@@ -60,7 +60,7 @@ services:
       #- strapi-de-sol1-data:/var/lib/postgresql/data/ #using a volume
       - ./data/postgresql/data:/var/lib/postgresql/data/ # if you want to use a bind folder
     ports:
-      - 5434:5432
+      - 5439:5432
     networks:
       - strapi-de-sol1
     healthcheck:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -69,16 +69,6 @@ services:
       timeout: 5s
       retries: 3
 
-  adminer:
-    image: adminer
-    ports:
-      - 8080:8080
-    networks:
-      - strapi-de-sol1
-    restart: always
-    depends_on:
-      - strapi-de-sol1DB
-
 volumes:
   strapi-de-sol1-data:
   lookup_node_modules:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -3,7 +3,7 @@ services:
   strapi-de-sol1:
     container_name: strapi-de-sol1
     build:
-      dockerfile: ./Dockerfile.prod
+      dockerfile: ./Dockerfile.test
     image: strapi-de-sol1:latest
     restart: unless-stopped
     env_file: .env

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,15 +1,15 @@
 version: '3'
 services:
-  strapi-rpb:
-    container_name: strapi-rpb
+  strapi-de-sol1:
+    container_name: strapi-de-sol1
     build:
       dockerfile: ./Dockerfile.prod
-    image: strapi-rpb:latest
+    image: strapi-de-sol1:latest
     restart: unless-stopped
     env_file: .env
     environment:
       DATABASE_CLIENT: ${DATABASE_CLIENT}
-      DATABASE_HOST: strapi-rpbDB
+      DATABASE_HOST: strapi-de-sol1DB
       DATABASE_PORT: ${DATABASE_PORT}
       DATABASE_NAME: ${DATABASE_NAME}
       DATABASE_USERNAME: ${DATABASE_USERNAME}
@@ -31,13 +31,13 @@ services:
     ports:
       - 1339:1337
     networks:
-      - strapi-rpb
+      - strapi-de-sol1
     depends_on:
-      strapi-rpbDB:
+      strapi-de-sol1DB:
         condition: service_healthy
 
-  strapi-rpbDB:
-    container_name: strapi-rpbDB
+  strapi-de-sol1DB:
+    container_name: strapi-de-sol1DB
     platform: linux/amd64 #for platform error on Apple M1 chips
     restart: unless-stopped
     env_file: .env
@@ -57,12 +57,12 @@ services:
       POSTGRES_DB: ${DATABASE_NAME}
     command: postgres -c statement_timeout=10min
     volumes:
-      #- strapi-rpb-data:/var/lib/postgresql/data/ #using a volume
+      #- strapi-de-sol1-data:/var/lib/postgresql/data/ #using a volume
       - ./data/postgresql/data:/var/lib/postgresql/data/ # if you want to use a bind folder
     ports:
       - 5434:5432
     networks:
-      - strapi-rpb
+      - strapi-de-sol1
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U strapi"]
       interval: 5s
@@ -74,16 +74,16 @@ services:
     ports:
       - 8080:8080
     networks:
-      - strapi-rpb
+      - strapi-de-sol1
     restart: always
     depends_on:
-      - strapi-rpbDB
+      - strapi-de-sol1DB
 
 volumes:
-  strapi-rpb-data:
+  strapi-de-sol1-data:
   lookup_node_modules:
 
 networks:
-  strapi-rpb:
-    name: strapi-rpb
+  strapi-de-sol1:
+    name: strapi-de-sol1
     driver: bridge

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -29,7 +29,7 @@ services:
       - ./public:/opt/app/public
       - ./backup:/opt/app/backup
     ports:
-      - 1339:1337
+      - 1344:1337
     networks:
       - strapi-de-sol1
     depends_on:
@@ -60,7 +60,7 @@ services:
       #- strapi-de-sol1-data:/var/lib/postgresql/data/ #using a volume
       - ./data/postgresql/data:/var/lib/postgresql/data/ # if you want to use a bind folder
     ports:
-      - 5434:5432
+      - 5439:5432
     networks:
       - strapi-de-sol1
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 
 version: '3'
 services:
-  strapi-rpb:
-    container_name: strapi-rpb
+  strapi-de-sol1:
+    container_name: strapi-de-sol1
     build:
       dockerfile: ./Dockerfile.dev
       network: host
-    image: strapi-rpb:latest
+    image: strapi-de-sol1:latest
     restart: unless-stopped
     env_file: .env
     environment:
       DATABASE_CLIENT: ${DATABASE_CLIENT}
-      DATABASE_HOST: strapi-rpbDB
+      DATABASE_HOST: strapi-de-sol1DB
       DATABASE_PORT: ${DATABASE_PORT}
       DATABASE_NAME: ${DATABASE_NAME}
       DATABASE_USERNAME: ${DATABASE_USERNAME}
@@ -33,15 +33,15 @@ services:
       - 1337:1337
       - 8000:8000
     networks:
-      - strapi-rpb
+      - strapi-de-sol1
     depends_on:
-      strapi-rpbDB:
+      strapi-de-sol1DB:
         condition: service_healthy
     extra_hosts:
     - "host.docker.internal:host-gateway"
       
-  strapi-rpbDB:
-    container_name: strapi-rpbDB
+  strapi-de-sol1DB:
+    container_name: strapi-de-sol1DB
     platform: linux/amd64 #for platform error on Apple M1 chips
     restart: unless-stopped
     env_file: .env
@@ -53,12 +53,12 @@ services:
       POSTGRES_DB: ${DATABASE_NAME}
     command: postgres -c statement_timeout=1min
     volumes:
-      - strapi-rpb-data:/var/lib/postgresql/data/ #using a volume
+      - strapi-de-sol1-data:/var/lib/postgresql/data/ #using a volume
       #- ./data:/var/lib/postgresql/data/ # if you want to use a bind folder
     ports:
       - 5434:5432
     networks:
-      - strapi-rpb
+      - strapi-de-sol1
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U strapi"]
       interval: 5s
@@ -70,16 +70,16 @@ services:
     ports:
       - 8080:8080
     networks:
-      - strapi-rpb
+      - strapi-de-sol1
     restart: always
     depends_on:
-      - strapi-rpbDB
+      - strapi-de-sol1DB
 
 volumes:
-  strapi-rpb-data:
+  strapi-de-sol1-data:
   lookup_node_modules:
 
 networks:
-  strapi-rpb:
-    name: strapi-rpb
+  strapi-de-sol1:
+    name: strapi-de-sol1
     driver: bridge


### PR DESCRIPTION
See #1 

As opposed to rpb the de-sol1 test instance is running in development mode, not production mode.