### PR TITLE
Add hook to fetch almaMmsId, hbzId, and zdbId when saving (#3)

### DIFF
--- a/src/api/holding/content-types/holding/lifecycles.js
+++ b/src/api/holding/content-types/holding/lifecycles.js
@@ -2,14 +2,21 @@ const fetch = require("node-fetch");
 
 module.exports = {
     async beforeUpdate(event) {
-        const data = event.params.data;
-        const [almaMmsId, hbzId, zdbId] =
-            await fetchFields(data.lobidUri, ["almaMmsId", "hbzId", "zdbId"]);
-        data.almaMmsId = almaMmsId;
-        data.hbzId = hbzId;
-        data.zdbId = zdbId;
+        await fetchData(event);
+    },
+    async beforeCreate(event) {
+        await fetchData(event);
     }
 };
+
+const fetchData = async (event) => {
+    const data = event.params.data;
+    const [almaMmsId, hbzId, zdbId] =
+        await fetchFields(data.lobidUri, ["almaMmsId", "hbzId", "zdbId"]);
+    data.almaMmsId = almaMmsId;
+    data.hbzId = hbzId;
+    data.zdbId = zdbId;
+}
 
 const fetchFields = async (lobidUri, fields) => {
     const url = `${lobidUri.replace("#!", "")}?format=json`;


### PR DESCRIPTION
Will resolve #8.

Fetch almaMmsId, hbzId, and zdbId fields based on the lobidUri when saving in Strapi.

(Didn't fetch title since we have no `title` field in the content type and the title is already displayed below the `lobidUri` field).