### PR TITLE
Only fetch additional data for holdings created via UI (#19)

### DIFF
--- a/src/api/holding/content-types/holding/lifecycles.js
+++ b/src/api/holding/content-types/holding/lifecycles.js
@@ -5,7 +5,7 @@ module.exports = {
         await fetchData(event);
     },
     async beforeCreate(event) {
-        await fetchData(event);
+        event.params.data.createdBy && await fetchData(event);
     }
 };
 


### PR DESCRIPTION
Don't fetch data in API import, where `createdBy` is `undefined`.

Should resolve #19.