### PR TITLE
Disable draft options #23

### DIFF
--- a/src/api/holding/content-types/holding/schema.json
+++ b/src/api/holding/content-types/holding/schema.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": true
+    "draftAndPublish": false
   },
   "pluginOptions": {},
   "attributes": {


### PR DESCRIPTION
As suggested by @fsteeg :

I disabled the option for creating drafts. Saving does not create any errors.

As I mentioned in #23 this seems to me more like a workaround. We should somehow understand and document the underlying problem.